### PR TITLE
Return a tuple as per the `struct.unpack` API

### DIFF
--- a/solrbackup.py
+++ b/solrbackup.py
@@ -46,7 +46,7 @@ class FileStream(object):
         if buf:
             return struct.unpack(fmt, buf)
         else:
-            return None
+            return (None,)
 
     def next(self):
         size, = self.unpack('>i')


### PR DESCRIPTION
The call to `self.unpack` on line 52 can with "`NoneType` not iterable" if it is passed `None` because there is no `tuple` to unwrap.